### PR TITLE
Remove 'install getopt' error message on invalid option condition.

### DIFF
--- a/bashGeneratorSharedModels/Resources/bashTemplate.sh
+++ b/bashGeneratorSharedModels/Resources/bashTemplate.sh
@@ -61,7 +61,6 @@ function parseInput() {
     if [[ ${PIPESTATUS[0]} -ne 0 ]]; then
         # e.g. return value is 1
         # then getopt has complained about wrong arguments to stdout
-        echoError "you might be running bash on a Mac.  if so, run 'brew install gnu-getopt' to make the command line processing work."
         usage
         exit 2
     fi


### PR DESCRIPTION
Simple change to remove error message when an invalid option set is provided.  The rationale is that there is already a previous check for existance of "getopts", so this additional message is not needed.  With the red highlighting, it is also distracting compared to more desired response of usage.  